### PR TITLE
Update backend routes and avatar upload

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -189,14 +189,19 @@ function setupAuthListeners() {
     const name = document.getElementById('register-name').value;
     const username = document.getElementById('register-username').value;
     const password = document.getElementById('register-password').value;
-    
+
+    const formData = new FormData();
+    formData.append('name', name);
+    formData.append('username', username);
+    formData.append('password', password);
+    if (dom.avatarInput.files[0]) {
+      formData.append('avatar', dom.avatarInput.files[0]);
+    }
+
     try {
       const response = await fetch(`${config.apiBaseUrl}/api/register`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ name, username, password })
+        body: formData
       });
       
       if (response.ok) {
@@ -305,7 +310,7 @@ function setupAppListeners() {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${localStorage.getItem('nexus_token')}`
         },
-        body: JSON.stringify({ name, avatar, members })
+        body: JSON.stringify({ name, avatar, usernames: members })
       });
       
       if (response.ok) {
@@ -1164,7 +1169,11 @@ function initPeerConnection() {
   };
   
   state.peerConnection.onconnectionstatechange = () => {
-    if (state.peerConnection.connectionState === 'disconnected') {
+    const stateStr = state.peerConnection.connectionState;
+    if (stateStr === 'connected') {
+      dom.callPreviewContainer.style.display = 'none';
+      dom.callContainer.style.display = 'flex';
+    } else if (stateStr === 'disconnected' || stateStr === 'failed' || stateStr === 'closed') {
       endCall();
     }
   };


### PR DESCRIPTION
## Summary
- implement `/api/users/me` route
- enable avatar upload during registration
- enrich `/api/users` list with presence and messages
- accept usernames when creating groups
- update CSP settings
- support avatar upload in registration form
- update group creation request
- show call container on WebRTC connection

## Testing
- `node --check server.js`
- `node --check public/main.js`


------
https://chatgpt.com/codex/tasks/task_b_6863d52b675c832488ee71b131844112