### PR TITLE
Fix websocket auth token

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -883,8 +883,14 @@ async function uploadFile(file) {
  */
 function connectSocket() {
   if (state.socket) return;
-  
-  state.socket = io(config.socketOptions);
+
+  // Toujours récupérer le token courant depuis le stockage pour gérer
+  // les connexions établies après un login sans rechargement de la page
+  const token = localStorage.getItem('nexus_token');
+  state.socket = io({
+    ...config.socketOptions,
+    auth: { token }
+  });
   
   // Gestion des erreurs de connexion
   state.socket.on('connect_error', (err) => {


### PR DESCRIPTION
## Summary
- ensure connectSocket pulls the auth token from `localStorage` before connecting

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6863e3df5760832493180372dd341146