### PR TITLE
Improve group management and security

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "multer": "^1.4.5-lts.1",
     "cors": "^2.8.5",
     "socket.io": "^4.7.2",
-    "agenda": "^5.0.0"
+    "express-rate-limit": "^7.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- drop Agenda usage in favor of MongoDB TTL
- add request rate limiting and stronger validation
- implement group invitation workflow with accept/decline
- notify users of group invites via sockets and toast UI

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6863e7646d688324b71a33c227f33ab6