### PR TITLE
Improve mobile header and input layout

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1013,3 +1013,51 @@ button {
     from { opacity: 1; transform: translateX(0); }
     to { opacity: 0; transform: translateX(100%); }
 }
+
+/*
+===================================================================
+                        CORRECTIONS RESPONSIVE MOBILE
+===================================================================
+*/
+
+@media (max-width: 767px) {
+
+    /* --- En-tête de la conversation --- */
+    .chat-header .chat-partner {
+        display: flex;
+        flex-grow: 1;
+        align-items: center;
+        gap: 12px;
+    }
+
+    .chat-partner-info {
+        flex-grow: 1;
+        min-width: 0;
+    }
+
+    .chat-partner-name {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .chat-partner-status span {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    /* --- Zone de saisie --- */
+    #chat-form .input-group {
+        flex-grow: 1;
+    }
+
+    #chat-form .action-btn,
+    #chat-form .ttl-select {
+        flex-shrink: 0;
+    }
+
+    #message-input {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- adjust chat header layout for small screens
- enhance input area spacing and flexibility

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6863f0b40a008324a2e6d2f43a1528e6