### PR TITLE
Fix call UI & typing indicator, add group member management

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -128,19 +128,23 @@
                     </div>
                     <div class="chat-partner-info">
                         <div id="chat-partner-name" class="chat-partner-name">Jean Dupont</div>
-                        <div id="chat-partner-status-text" class="chat-partner-status">
-                            <span class="status-dot online"></span>
-                            <span>En ligne</span>
-                        </div>
+                    <div id="chat-partner-status-text" class="chat-partner-status">
+                        <span class="status-dot online"></span>
+                        <span>En ligne</span>
                     </div>
+                    <div id="typing-indicator-container" class="typing-indicator-container"></div>
                 </div>
-                
-                <div class="chat-actions">
-                    <button class="chat-action-btn call" aria-label="Appeler">
-                        <i class="fas fa-phone-alt"></i>
-                    </button>
-                    <button class="chat-action-btn video" aria-label="Appel vidéo">
-                        <i class="fas fa-video"></i>
+            </div>
+
+            <div class="chat-actions">
+                <button class="chat-action-btn group-settings hidden" aria-label="Gérer le groupe">
+                    <i class="fas fa-users-cog"></i>
+                </button>
+                <button class="chat-action-btn call" aria-label="Appeler">
+                    <i class="fas fa-phone-alt"></i>
+                </button>
+                <button class="chat-action-btn video" aria-label="Appel vidéo">
+                    <i class="fas fa-video"></i>
                     </button>
                 </div>
             </header>

--- a/public/style.css
+++ b/public/style.css
@@ -530,6 +530,19 @@ button {
     height: 8px;
 }
 
+.typing-indicator-container {
+    font-size: 0.8rem;
+    color: var(--color-primary);
+    height: 16px;
+    transition: opacity 0.3s;
+}
+.typing-indicator-container.visible {
+    opacity: 1;
+}
+.typing-indicator-container.hidden {
+    opacity: 0;
+}
+
 .chat-actions {
     display: flex;
     gap: var(--spacing-sm);


### PR DESCRIPTION
## Summary
- add route to remove group member and include member info in group messages
- update WebRTC connection handler to display call UI
- move typing indicator to header and update styling
- show/hide buttons when selecting chats vs groups
- add group settings button and placeholder handler

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6863f6def8988324a0cde6a51370dea9