### PR TITLE
Finalisation des discussions privées et groupes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -106,6 +106,9 @@
             </nav>
             
             <!-- Groups and Contacts -->
+            <h3 class="list-title">Discussions</h3>
+            <div class="contacts-list" id="contacts-list" role="list">
+            </div>
             <h3 class="list-title">Groupes</h3>
             <div class="contacts-list" id="groups-list" role="list"></div>
         </aside>


### PR DESCRIPTION
## Summary
- restructure sidebar to show private discussions and groups
- add private chat rendering in main interface
- highlight selected contact or group correctly
- implement typing indicator for groups
- extend server typing events to broadcast to groups

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6863fd69a7988324a493e368d31df642