### PR TITLE
Implémentation édition de messages et améliorations UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -88,6 +88,12 @@
 
         <!-- Zone de chat principale -->
         <div class="chat-area">
+            <div id="welcome-screen" style="display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100%; color: #888;">
+                <i class="fas fa-comments" style="font-size: 5rem; margin-bottom: 1rem;"></i>
+                <h2>Bienvenue sur Nexus Chat</h2>
+                <p>Sélectionnez une discussion pour commencer.</p>
+            </div>
+            <div id="chat-container" style="display: none; flex-direction: column; height: 100%;">
             <!-- En-tête de chat -->
             <div class="chat-header">
                 <div class="chat-info">

--- a/public/style.css
+++ b/public/style.css
@@ -812,3 +812,10 @@ body {
         display: block;
     }
 }
+
+.empty-state {
+    padding: 1rem;
+    text-align: center;
+    color: #999;
+    font-style: italic;
+}


### PR DESCRIPTION
## Summary
- enable search filtering, message edit flow, empty states
- add welcome screen toggle and send button behavior
- allow emoji prompt when reacting
- support message editing on backend
- add welcome screen container in HTML and styles for empty state

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68643ab5b1d083248dd2e14f823cc61e