### PR TITLE
Improve chat message grouping

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -734,6 +734,63 @@ button {
     height: 30px;
 }
 
+/* --- Styles pour le groupement de messages --- */
+.message-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-right: var(--spacing-sm);
+}
+
+.message-sender {
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
+    margin: 0 var(--spacing-sm);
+}
+
+/* Réduire la marge entre les messages d'un même groupe */
+.message.group-middle,
+.message:not(.group-start) {
+    margin-top: -6px; /* 8px gap - 6px = 2px visible */
+}
+
+/* Cacher l'avatar pour les messages qui ne sont pas en début de groupe */
+.message.received:not(.group-start) .message-avatar {
+    visibility: hidden;
+}
+
+/* Ajuster les border-radius pour les bulles de message */
+/* Message reçu */
+.message.received.group-start:not(.group-end) .message-content {
+    border-bottom-left-radius: 4px;
+}
+.message.received:not(.group-start):not(.group-end) .message-content {
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+}
+.message.received.group-end:not(.group-start) .message-content {
+    border-top-left-radius: 4px;
+}
+
+/* Message envoyé */
+.message.sent.group-start:not(.group-end) .message-content {
+    border-bottom-right-radius: 4px;
+}
+.message.sent:not(.group-start):not(.group-end) .message-content {
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+}
+.message.sent.group-end:not(.group-start) .message-content {
+    border-top-right-radius: 4px;
+}
+
+/* Masquer les informations redondantes */
+.message:not(.group-end) .message-info .timestamp,
+.message:not(.group-end) .message-info .read-receipt {
+    display: none;
+}
+
 
 /* Chat Input Area */
 .chat-input-area {


### PR DESCRIPTION
## Summary
- group consecutive messages on the client so messages from the same sender appear as a single block
- show avatars and sender names only at the start of a group
- style grouped messages with tighter spacing and adjusted bubble corners

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6864e609b6d88324bfbc4ab0b2d68ce0